### PR TITLE
Remove trailing wilds from sig

### DIFF
--- a/makesig.py
+++ b/makesig.py
@@ -78,8 +78,7 @@ def cleanupWilds(byte_pattern):
 	for byte in reversed(byte_pattern):
 		if byte.is_wildcard is False:
 			break
-		else:
-			del byte_pattern[-1]
+		del byte_pattern[-1]
 
 def process(start_at = MAKE_SIG_AT['fn']):
 	fm = currentProgram.getFunctionManager()

--- a/makesig.py
+++ b/makesig.py
@@ -73,6 +73,14 @@ def getMaskedInstruction(ins):
 		else:
 			yield BytePattern(byte = b & 0xFF, is_wildcard = False)
 
+# removes trailing wilds from the sig
+def cleanupWilds(byte_pattern):
+	for byte in reversed(byte_pattern):
+		if byte.is_wildcard is False:
+			break
+		else:
+			del byte_pattern[-1]
+
 def process(start_at = MAKE_SIG_AT['fn']):
 	fm = currentProgram.getFunctionManager()
 	fn = fm.getFunctionContaining(currentAddress)
@@ -128,6 +136,7 @@ def process(start_at = MAKE_SIG_AT['fn']):
 		print('Signature matched', len(matches), 'locations:', *(matches))
 		raise Exception("Could not find unique signature")
 	else:
+		cleanupWilds(byte_pattern)
 		print("Signature for", fn.getName())
 		print(*(b.ida_str() for b in byte_pattern))
 		print("".join(b.sig_str() for b in byte_pattern))


### PR DESCRIPTION
Attempts to take a unique signature and remove any trailing wilds put in by the last instruction of the signature. Result of removing the wilds would still be unique from the other bytes added by the last instruction.