### PR TITLE
Uses PrintErr to communicate error messages

### DIFF
--- a/makesig.py
+++ b/makesig.py
@@ -105,9 +105,10 @@ def process(start_at = MAKE_SIG_AT['fn']):
 		ins = ins.getNext()
 		
 		if ins.getAddress() != expected_next:
-			printerr("Instruction at %s is not adjacent"
-					" to previous (expected %s)" % (expected_next, ins.getAddress()))
-			break
+			# add wildcards until we get to the next instruction
+			for _ in range(ins.getAddress().subtract(expected_next)):
+				byte_pattern.append(BytePattern(is_wildcard = True, byte = None))
+				pattern += '.'
 		
 		if 0 < len(matches) < match_limit:
 			# we have all the remaining matches, start only searching those addresses

--- a/makesig.py
+++ b/makesig.py
@@ -136,6 +136,6 @@ if __name__ == "__main__":
 	fn = fm.getFunctionContaining(currentAddress)
 	if not fn:
 		printerr("Not in a function")
-
-	start_at = askChoice("makesig", "Make sig at:", MAKE_SIG_AT.values(), MAKE_SIG_AT['fn'])
-	process(start_at)
+        else:
+	        start_at = askChoice("makesig", "Make sig at:", MAKE_SIG_AT.values(), MAKE_SIG_AT['fn'])
+	        process(start_at)

--- a/makesig.py
+++ b/makesig.py
@@ -105,10 +105,9 @@ def process(start_at = MAKE_SIG_AT['fn']):
 		ins = ins.getNext()
 		
 		if ins.getAddress() != expected_next:
-			# we don't have a good way to deal with alignment bytes
-			# raise an exception for now
-			raise Exception("Instruction at %s is not adjacent"
+			printerr("Instruction at %s is not adjacent"
 					" to previous (expected %s)" % (expected_next, ins.getAddress()))
+			break
 		
 		if 0 < len(matches) < match_limit:
 			# we have all the remaining matches, start only searching those addresses
@@ -126,7 +125,7 @@ def process(start_at = MAKE_SIG_AT['fn']):
 	if not len(matches) == 1:
 		print(*(b.ida_str() for b in byte_pattern))
 		print('Signature matched', len(matches), 'locations:', *(matches))
-		raise Exception("Could not find unique signature")
+		printerr("Could not find unique signature")
 	else:
 		print("Signature for", fn.getName())
 		print(*(b.ida_str() for b in byte_pattern))
@@ -136,7 +135,7 @@ if __name__ == "__main__":
 	fm = currentProgram.getFunctionManager()
 	fn = fm.getFunctionContaining(currentAddress)
 	if not fn:
-		raise Exception("Not in a function")
+		printerr("Not in a function")
 
 	start_at = askChoice("makesig", "Make sig at:", MAKE_SIG_AT.values(), MAKE_SIG_AT['fn'])
 	process(start_at)


### PR DESCRIPTION
Switches from raise exception to printerr to communicate error messages. There are situations where a signature cannot be found and the printerr displays the error message in red text while withholding the additional information triggered by raising an exception.