### PR TITLE
Force Jython because PyGhidra in 12.0+ is pain and suffering

### DIFF
--- a/makesig.py
+++ b/makesig.py
@@ -1,6 +1,7 @@
 #Generates a SourceMod-ready signature.
 #@author nosoop
 #@category _NEW_
+#@runtime Jython
 #@keybinding 
 #@menupath 
 #@toolbar 


### PR DESCRIPTION
PyGhidra gives some obtuse errors.
Wrapping `MAKE_SIG_AT.values()` as `list(MAKE_SIG_AT.values())` doesn't fix it because I have no idea how to fudge the last parameter into an object that PyGhidra wants.

Jython is what was used forever and is fine so let's keep using it forevermore!

```
Traceback (most recent call last):
  File "/home/rtldg/.config/ghidra/scripts/makesig.py", line 157, in <module>
    start_at = askChoice("makesig", "Make sig at:", MAKE_SIG_AT.values(), MAKE_SIG_AT['fn'])
TypeError: No matching overloads found for ghidra.app.script.GhidraScript.askChoice(str,str,odict_values,str), options are:
	public java.lang.Object ghidra.app.script.GhidraScript.askChoice(java.lang.String,java.lang.String,java.util.List,java.lang.Object) throws ghidra.util.exception.CancelledException
```